### PR TITLE
Refactor Cam and CamManip into separate files

### DIFF
--- a/qtOWL/CMakeLists.txt
+++ b/qtOWL/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(qtOWL STATIC
   InspectMode.cpp
   FlyMode.cpp
   Camera.cpp
+  CameraManip.cpp
 
   AlphaEditor.h
   AlphaEditor.cpp

--- a/qtOWL/Camera.cpp
+++ b/qtOWL/Camera.cpp
@@ -15,7 +15,6 @@
 // ======================================================================== //
 
 #include "Camera.h"
-#include "OWLViewer.h"
 
 namespace qtOWL {
 
@@ -86,73 +85,6 @@ namespace qtOWL {
     poiDistance = length(interest-origin);
     if (setFocalDistance) focalDistance = poiDistance;
     forceUpFrame();
-  }
-
-  /*! this gets called when the user presses a key on the keyboard ... */
-  void CameraManipulator::key(char key, const vec2i &where)
-  {
-    // int key = event->key();
-    Camera &fc = viewer->camera;
-
-    switch(key) {
-    case 'f':
-    case 'F':
-      if (viewer->flyModeManipulator)
-        viewer->cameraManipulator = viewer->flyModeManipulator;
-      break;
-    case 'i':
-    case 'I':
-      if (viewer->inspectModeManipulator)
-        viewer->cameraManipulator = viewer->inspectModeManipulator;
-      break;
-    case '+':
-    case '=':
-      fc.motionSpeed *= 2.f;
-      std::cout << "# viewer: new motion speed is " << fc.motionSpeed << std::endl;
-      break;
-    case '-':
-    case '_':
-      fc.motionSpeed /= 2.f;
-      std::cout << "# viewer: new motion speed is " << fc.motionSpeed << std::endl;
-      break;
-    case 'C': {
-      std::cout << "(C)urrent camera:" << std::endl;
-      std::cout << "- from :" << fc.position << std::endl;
-      std::cout << "- poi  :" << fc.getPOI() << std::endl;
-      std::cout << "- upVec:" << fc.upVector << std::endl;
-      std::cout << "- frame:" << fc.frame << std::endl;
-
-      const vec3f vp = fc.position;
-      const vec3f vi = fc.getPOI();
-      const vec3f vu = fc.upVector;
-      const float fovy = fc.getFovyInDegrees();
-      std::cout << "(suggested cmdline format, for apps that support this:) "
-                << std::endl
-                << " --camera"
-                << " " << vp.x << " " << vp.y << " " << vp.z
-                << " " << vi.x << " " << vi.y << " " << vi.z
-                << " " << vu.x << " " << vu.y << " " << vu.z
-                << " -fovy " << fovy
-                << std::endl;
-    } break;
-    case 'x':
-    case 'X':
-      fc.setUpVector(fc.upVector==vec3f(1,0,0)?vec3f(-1,0,0):vec3f(1,0,0));
-      viewer->updateCamera();
-      break;
-    case 'y':
-    case 'Y':
-      fc.setUpVector(fc.upVector==vec3f(0,1,0)?vec3f(0,-1,0):vec3f(0,1,0));
-      viewer->updateCamera();
-      break;
-    case 'z':
-    case 'Z':
-      fc.setUpVector(fc.upVector==vec3f(0,0,1)?vec3f(0,0,-1):vec3f(0,0,1));
-      viewer->updateCamera();
-      break;
-    default:
-      break;
-    }
   }
 
 } // ::owlQT

--- a/qtOWL/Camera.h
+++ b/qtOWL/Camera.h
@@ -19,8 +19,6 @@
 #include "owl/common/math/box.h"
 #include "owl/common/math/LinearSpace.h"
 
-#include <QKeyEvent>
-
 #include <vector>
 #include <memory>
 #ifdef _GNUC_
@@ -34,8 +32,6 @@ namespace qtOWL {
   
   inline float toRadian(float deg) { return deg * float(M_PI/180.f); }
   inline float toDegrees(float rad) { return rad / float(M_PI/180.f); }
-
-  struct OWLViewer;
 
   /*! the entire state for someting that can 'control' a camera -
     ie, that can rotate, move, focus, force-up, etc, a
@@ -106,47 +102,6 @@ namespace qtOWL {
     float         fovyInDegrees { 60.f };
 
     double        lastModified = 0.;
-  };
-
-  // ------------------------------------------------------------------
-  /*! abstract base class that allows to manipulate a renderable
-    camera */
-  struct CameraManipulator {
-    CameraManipulator(OWLViewer *viewer) : viewer(viewer) {}
-
-   /*! this gets called when the user presses a key on the keyboard ... */
-    virtual void key(char key, const vec2i &/*where*/);
-    
-
-    //  /*! this gets called when the user presses a key on the keyboard ... */
-    // virtual void key(QKeyEvent *event);
-
-    /*! this gets called when the user presses a key on the keyboard ... */
-     virtual void special(QKeyEvent *event, const vec2i &where) { };
-
-    /*! mouse got dragged with left button pressedn, by 'delta'
-      pixels, at last position where */
-    virtual void mouseDragLeft  (const vec2i &where, const vec2i &delta) {}
-
-    /*! mouse got dragged with left button pressedn, by 'delta'
-      pixels, at last position where */
-    virtual void mouseDragCenter(const vec2i &where, const vec2i &delta) {}
-
-    /*! mouse got dragged with left button pressedn, by 'delta'
-      pixels, at last position where */
-    virtual void mouseDragRight (const vec2i &where, const vec2i &delta) {}
-
-    /*! mouse button got either pressed or released at given location */
-    virtual void mouseButtonLeft  (const vec2i &where, bool pressed) {}
-
-    /*! mouse button got either pressed or released at given location */
-    virtual void mouseButtonCenter(const vec2i &where, bool pressed) {}
-
-    /*! mouse button got either pressed or released at given location */
-    virtual void mouseButtonRight (const vec2i &where, bool pressed) {}
-
-  protected:
-    OWLViewer *const viewer;
   };
 
 } // ::owlQT

--- a/qtOWL/FlyMode.h
+++ b/qtOWL/FlyMode.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "Camera.h"
+#include "CameraManip.h"
 
 namespace qtOWL {
 

--- a/qtOWL/InspectMode.h
+++ b/qtOWL/InspectMode.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "Camera.h"
+#include "CameraManip.h"
 
 namespace qtOWL {
 

--- a/qtOWL/OWLViewer.h
+++ b/qtOWL/OWLViewer.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "qtOWL/Camera.h"
+#include "qtOWL/CameraManip.h"
 
 #include <QOpenGLWidget>
 #include <QOpenGLFunctions>


### PR DESCRIPTION
That lifts the dependency against Qt of the camera class. That way I can use the Camera.{h|cpp} files directly in my project w/o all the rest; note though that user code now has to include `CameraManip.h` in addition to `Camera.h` _if_ it uses the manipulator.