### PR TITLE
Make cuda optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ endif()
 
 project(Cutee-OWL VERSION 0.0.1)
 
+option(CUTEEOWL_USE_CUDA "Build with CUDA frame buffer implementation" ON)
+if(CUTEEOWL_USE_CUDA)
+  find_package(CUDAToolkit)
+endif()
+
 # ------------------------------------------------------------------
 # add owl, for vec3f stuff used in viewer
 # ------------------------------------------------------------------
@@ -41,8 +46,10 @@ add_subdirectory(qtOWL)
 
 
 
-add_executable(sampleViewer apps/sample.cpp)
-target_link_libraries(sampleViewer PRIVATE qtOWL)
+if(CUDAToolkit_FOUND)
+  add_executable(sampleViewer apps/sample.cpp)
+  target_link_libraries(sampleViewer PRIVATE qtOWL)
+endif()
 
 
 

--- a/qtOWL/CMakeLists.txt
+++ b/qtOWL/CMakeLists.txt
@@ -44,7 +44,7 @@ target_sources(qtOWL PRIVATE
   ColorMaps.h
   ColorMaps.cpp
 )
-target_link_libraries(qtOWL PUBLIC owl::owl Qt5::Widgets stb_image OpenGL::GL)
+target_link_libraries(qtOWL PUBLIC owl::owl Qt5::Widgets OpenGL::GL)
 target_include_directories(qtOWL PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
 if(CUDAToolkit_FOUND)
   target_link_libraries(qtOWL PUBLIC CUDA::cudart)

--- a/qtOWL/CMakeLists.txt
+++ b/qtOWL/CMakeLists.txt
@@ -46,3 +46,7 @@ target_sources(qtOWL PRIVATE
 )
 target_link_libraries(qtOWL PUBLIC owl::owl Qt5::Widgets stb_image OpenGL::GL)
 target_include_directories(qtOWL PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
+if(CUDAToolkit_FOUND)
+  target_link_libraries(qtOWL PUBLIC CUDA::cudart)
+  target_compile_definitions(qtOWL PUBLIC CUTEEOWL_USE_CUDA=1)
+endif()

--- a/qtOWL/OWLViewer.h
+++ b/qtOWL/OWLViewer.h
@@ -25,8 +25,7 @@
 #include <QApplication>
 #include <QMainWindow>
 
-#include <cuda_runtime.h>
-#include <cuda_gl_interop.h>
+typedef struct cudaGraphicsResource* cudaGraphicsResource_t;
 
 QT_FORWARD_DECLARE_CLASS(QOpenGLShaderProgram);
 QT_FORWARD_DECLARE_CLASS(QOpenGLTexture)


### PR DESCRIPTION
This PR implements a fallback on the host if the CUDA toolkit wasn't found; also fixes a bug where the co-dependent targets wouldn't link as `stb_image` can't be linked with.