### PR TITLE
Port to Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,13 +46,20 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # and in the 'real' app set the POSITION_INDEPENDENT_CODE flag to on, as well
 # as set CMAKE_CXX_COMPILE_OPTIONS_PIE to "-fPIC" for those targets that
 # actually use a C++ compiler that understands this.
-find_package(Qt5Widgets REQUIRED)
-get_property(core_options TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
+option(CUTEEOWL_FORCE_QT5 "Enforce the use of Qt5 even if newer available" OFF)
+if (NOT CUTEEOWL_FORCE_QT5)
+    find_package(Qt6 COMPONENTS Widgets)
+endif()
+if (NOT Qt6_FOUND)
+    # Require Qt 5.15 which adds version-less targets (Qt::XXX vs. Qt5::XXX)
+    find_package(Qt5 5.15 REQUIRED COMPONENTS Widgets)
+    get_property(core_options TARGET Qt::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
+endif()
 if(${core_options})
 string(REPLACE "-fPIC" "" new_core_options ${core_options})
-set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
+set_property(TARGET Qt::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
 endif()
-set_property(TARGET Qt5::Core PROPERTY INTERFACE_POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET Qt::Core PROPERTY INTERFACE_POSITION_INDEPENDENT_CODE ON)
   
 
 # ------------------------------------------------------------------
@@ -70,7 +77,7 @@ IF (NOT CUTEE_OWL_IS_SUBPROJECT)
   
   add_executable(sampleViewer apps/sample.cpp)
   set_property(TARGET sampleViewer PROPERTY INTERFACE_POSITION_INDEPENDENT_CODE ON)
-  target_link_libraries(sampleViewer PRIVATE qtOWL  Qt5::Widgets)
+  target_link_libraries(sampleViewer PRIVATE qtOWL  Qt::Widgets)
 endif()
 #endif()
 

--- a/cutee/AlphaEditor.cpp
+++ b/cutee/AlphaEditor.cpp
@@ -20,7 +20,10 @@
 #include <QMouseEvent>
 #include <math.h>
 #include <QApplication>
+
+#ifdef WITH_QT5
 #include <QDesktopWidget>
+#endif
 
 namespace cutee {
 
@@ -56,10 +59,15 @@ namespace cutee {
   
   QSize AlphaEditor::sizeHint() const
   {
+#ifdef WITH_QT5
     QRect rec = QApplication::desktop()->screenGeometry();
     int height = rec.height();
     int width = rec.width();
     return QSize(width/6, height/6);
+#else
+    std::cerr << "sizeHint() not available on Qt6 or newer..\n";
+    return QSize(-1,-1);
+#endif
   }
 
   void AlphaEditor::initializeGL()

--- a/cutee/CMakeLists.txt
+++ b/cutee/CMakeLists.txt
@@ -17,15 +17,22 @@
 set(OpenGL_GL_PREFERENCE "LEGACY")
 find_package(OpenGL REQUIRED)
 
-find_package(Qt5Widgets REQUIRED)
+if (NOT CUTEEOWL_FORCE_QT5)
+    find_package(Qt6 COMPONENTS Widgets OpenGLWidgets)
+endif()
+if (NOT Qt6_FOUND)
+    find_package(Qt5 5.15 REQUIRED COMPONENTS Widgets)
+    # Create dummy target for Qt::OpenGLWidgets as Qt5 does not have that
+    add_library(Qt::OpenGLWidgets INTERFACE IMPORTED)
+endif()
 set(CMAKE_AUTOMOC ON)
 
-get_property(core_options TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
+get_property(core_options TARGET Qt::Core PROPERTY INTERFACE_COMPILE_OPTIONS)
 if(${core_options})
 string(REPLACE "-fPIC" "" new_core_options ${core_options})
 endif(${core_options})
-set_property(TARGET Qt5::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
-set_property(TARGET Qt5::Core PROPERTY INTERFACE_POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET Qt::Core PROPERTY INTERFACE_COMPILE_OPTIONS ${new_core_options})
+set_property(TARGET Qt::Core PROPERTY INTERFACE_POSITION_INDEPENDENT_CODE ON)
 
 
 add_library(qtOWL STATIC)
@@ -44,7 +51,7 @@ target_sources(qtOWL PRIVATE
   ColorMaps.h
   ColorMaps.cpp
 )
-target_link_libraries(qtOWL PUBLIC Qt5::Widgets OpenGL::GL)
+target_link_libraries(qtOWL PUBLIC Qt::Widgets Qt::OpenGLWidgets OpenGL::GL)
 target_include_directories(qtOWL PUBLIC ${CMAKE_CURRENT_LIST_DIR}/..)
 #if(CUDAToolkit_FOUND)
 #  target_link_libraries(qtOWL PUBLIC CUDA::cudart)

--- a/cutee/OWLViewer.cpp
+++ b/cutee/OWLViewer.cpp
@@ -20,7 +20,10 @@
 #include <QMouseEvent>
 #include <math.h>
 #include <QApplication>
+
+#ifdef WITH_QT5
 #include <QDesktopWidget>
+#endif
 
 #include "InspectMode.h"
 #include "FlyMode.h"
@@ -127,10 +130,14 @@ namespace cutee {
     if (userSizeHint != vec2i(0))
       return QSize(userSizeHint.x,userSizeHint.y);
     else {
+#ifdef WITH_QT5
       QRect rec = QApplication::desktop()->screenGeometry();
       int height = rec.height();
       int width = rec.width();
       return QSize(width/2, height/2);
+#else
+      return QSize(800, 600);
+#endif
     }
   }
 
@@ -212,10 +219,15 @@ namespace cutee {
 
   vec2i OWLViewer::getScreenSize()
   {
+#ifdef WITH_QT5
     QRect rec = QApplication::desktop()->screenGeometry();
     int height = rec.height();
     int width = rec.width();
     return {width, height};
+#else
+    std::cerr << "getScreenSize() not available on Qt6 or newer..\n";
+    return {-1, -1};
+#endif
   }
 
   float computeStableEpsilon(float f)
@@ -540,7 +552,7 @@ namespace cutee {
       // leftButton.altWhenPressed   = (mods & GLFW_MOD_ALT    );
       mouseButtonLeft(lastMousePos, pressed);
       break;
-    case Qt::MidButton://GLFW_MOUSE_BUTTON_MIDDLE:
+    case Qt::MiddleButton://GLFW_MOUSE_BUTTON_MIDDLE:
       centerButton.isPressed = pressed;
       // centerButton.shiftWhenPressed = (mods & GLFW_MOD_SHIFT  );
       // centerButton.ctrlWhenPressed  = (mods & GLFW_MOD_CONTROL);
@@ -575,7 +587,7 @@ namespace cutee {
       // leftButton.altWhenPressed   = (mods & GLFW_MOD_ALT    );
       mouseButtonLeft(lastMousePos, pressed);
       break;
-    case Qt::MidButton://GLFW_MOUSE_BUTTON_MIDDLE:
+    case Qt::MiddleButton://GLFW_MOUSE_BUTTON_MIDDLE:
       centerButton.isPressed = pressed;
       // centerButton.shiftWhenPressed = (mods & GLFW_MOD_SHIFT  );
       // centerButton.ctrlWhenPressed  = (mods & GLFW_MOD_CONTROL);

--- a/cutee/common/cutee-common.h
+++ b/cutee/common/cutee-common.h
@@ -18,6 +18,13 @@
 
 #pragma once
 
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+# define WITH_QT5
+#else
+# define WITH_QT6
+#endif
+
 #ifndef _USE_MATH_DEFINES
 #  define _USE_MATH_DEFINES
 #endif


### PR DESCRIPTION
Alternatively Qt5 can be used but then the minimum version is 5.15 which adds support for version-less targets (eg. Qt::Widgets instead of Qt5::Widgets etc.)

Also adding a cmake option `CUTEE_FORCE_QT5` to make the transition a little smoother (I tested this on Ubuntu 22.04 / apt-get which has Qt5 and on homebrew where Qt6 is available but Qt5 comes with a buggy QTimer header).

I noticed later that I created this changeset against `iw/no-owl`, which probably makes sense as this branch has the latest changes; should we merge all those changes into `main` then?